### PR TITLE
Add hashing and chain verification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,21 +18,15 @@ add_executable(p4 main.cpp)
 target_link_libraries(p4 PRIVATE blockchain)
 
 # ---- Tests ----
-include(FetchContent)
-FetchContent_Declare(
-  googletest
-  URL https://github.com/google/googletest/archive/refs/tags/release-1.12.1.zip
-)
-# For Windows: prevent overriding the parent project's compiler/linker settings
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(googletest)
-
 enable_testing()
+
 add_executable(tests
+    gtest/gtest_main.cpp
     tests/test_transaction.cpp
     tests/test_blockchain.cpp
     tests/test_network.cpp
 )
-target_link_libraries(tests PRIVATE blockchain gtest_main)
+target_include_directories(tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(tests PRIVATE blockchain)
 add_test(NAME all_tests COMMAND tests)
 

--- a/block.cpp
+++ b/block.cpp
@@ -12,6 +12,34 @@ block::block(int bNumber, int maxTransactions) {
     currentNumTransactions = 0;
 }
 
+void block::computeHash() {
+    hash = calculateHash();
+}
+
+std::string block::calculateHash() const {
+    std::string data = prevHash + std::to_string(blockNumber);
+    for (const auto &t : bTransactions) {
+        data += std::to_string(t.getTranID());
+        data += std::to_string(t.getFromID());
+        data += std::to_string(t.getToID());
+        data += std::to_string(t.getTranAmount());
+        data += t.getTimeStamp();
+    }
+    return std::to_string(std::hash<std::string>{}(data));
+}
+
+std::string block::getHash() const {
+    return hash;
+}
+
+void block::setPrevHash(const std::string &pHash) {
+    prevHash = pHash;
+}
+
+std::string block::getPrevHash() const {
+    return prevHash;
+}
+
 void block::inseartTran(transaction t) {
     bTransactions.push_back(t);
     currentNumTransactions++;

--- a/block.h
+++ b/block.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <iostream>
 #include <vector>
+#include <string>
 #include "transaction.h"
 using namespace std;
 
@@ -14,10 +15,18 @@ class block
     int newFromValue;
     int newToValue;
     int numNodesInNetwork;
+    std::string hash;
+    std::string prevHash;
 public:
     block();
     block(int bNumber, int maxTransactions);
     void inseartTran(transaction t);
+
+    void computeHash();
+    std::string getHash() const;
+    void setPrevHash(const std::string &pHash);
+    std::string getPrevHash() const;
+    std::string calculateHash() const;
 
     void setBlockNumber(int bN);
     void setCurrNumTran(int cnt);

--- a/blockChain.cpp
+++ b/blockChain.cpp
@@ -7,18 +7,23 @@ blockChain::blockChain() {
 blockChain::blockChain(int tPerB) {
     bChain.push_front(block(currentNumBlocks, tPerB));
     currentNumBlocks = 1;
+    bChain.front().setPrevHash("0");
+    bChain.front().computeHash();
 }
 
 void blockChain::insertTran(const transaction &t) {
     if (bChain.empty() ||
         bChain.front().getCurrNumTran() == bChain.front().getMaxNumTran()) {
         block nB(currentNumBlocks, bChain.front().getMaxNumTran());
+        nB.setPrevHash(bChain.front().getHash());
         nB.inseartTran(t);
+        nB.computeHash();
         insertBlockFront(nB);
         cout << "Inserting transaction to block #" << currentNumBlocks
              << " in node " << t.getTNodeNum() << endl;
     } else {
         bChain.front().inseartTran(t);
+        bChain.front().computeHash();
         cout << "Inserting transaction to block #" << currentNumBlocks
              << " in node " << t.getTNodeNum() << endl;
     }
@@ -28,6 +33,20 @@ void blockChain::insertBlockFront(block b) {
     b.setNextBlock(&bChain.front());
     bChain.push_front(b);
     currentNumBlocks++;
+}
+
+bool blockChain::verifyChain() const {
+    std::string prev = "0";
+    for (auto it = bChain.crbegin(); it != bChain.crend(); ++it) {
+        if (it->calculateHash() != it->getHash()) {
+            return false;
+        }
+        if (it->getPrevHash() != prev) {
+            return false;
+        }
+        prev = it->getHash();
+    }
+    return true;
 }
 
 void blockChain::setCurrNumBlocks(int cnb) {

--- a/blockChain.h
+++ b/blockChain.h
@@ -15,6 +15,8 @@ public:
     void insertTran(const transaction &t);
     void insertBlockFront(block b);
 
+    bool verifyChain() const;
+
     void setCurrNumBlocks(int cnb);
     void setNodeNum(int node);
 

--- a/blockNetwork.cpp
+++ b/blockNetwork.cpp
@@ -97,4 +97,13 @@ void blockNetwork::display() {
     }
 }
 
+bool blockNetwork::verifyAllChains() const {
+    for (const auto &chain : allNodes) {
+        if (!chain.verifyChain()) {
+            return false;
+        }
+    }
+    return true;
+}
+
 

--- a/blockNetwork.h
+++ b/blockNetwork.h
@@ -34,4 +34,6 @@ public:
     void clearID();
 
     void display();
+
+    bool verifyAllChains() const;
 };

--- a/gtest/gtest.h
+++ b/gtest/gtest.h
@@ -1,0 +1,93 @@
+#ifndef GTEST_GTEST_H
+#define GTEST_GTEST_H
+
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <functional>
+#include <stdexcept>
+
+namespace testing {
+
+struct Test {
+    std::string name;
+    std::function<void()> func;
+};
+
+inline std::vector<Test>& registry() {
+    static std::vector<Test> r;
+    return r;
+}
+
+inline void RegisterTest(const std::string& name, std::function<void()> func) {
+    registry().push_back({name, func});
+}
+
+inline int RunAllTests() {
+    int failed = 0;
+    for (const auto& t : registry()) {
+        try {
+            t.func();
+            std::cout << "[       OK ] " << t.name << "\n";
+        } catch (const std::exception& e) {
+            std::cout << "[  FAILED  ] " << t.name << " - " << e.what() << "\n";
+            failed++;
+        }
+    }
+    if (failed) {
+        std::cout << failed << " test(s) failed\n";
+    } else {
+        std::cout << "All tests passed\n";
+    }
+    return failed;
+}
+
+namespace internal {
+inline std::stringstream& captured() {
+    static std::stringstream cap;
+    return cap;
+}
+inline std::streambuf*& oldBuf() {
+    static std::streambuf* buf = nullptr;
+    return buf;
+}
+
+inline void CaptureStdout() {
+    oldBuf() = std::cout.rdbuf(captured().rdbuf());
+}
+
+inline std::string GetCapturedStdout() {
+    std::cout.rdbuf(oldBuf());
+    oldBuf() = nullptr;
+    std::string s = captured().str();
+    captured().str("");
+    captured().clear();
+    return s;
+}
+} // namespace internal
+
+} // namespace testing
+
+#define TEST(Suite, Name) \
+    void Suite##_##Name(); \
+    namespace { \
+    struct Suite##_##Name##_Reg { \
+        Suite##_##Name##_Reg() { testing::RegisterTest(#Suite "." #Name, Suite##_##Name); } \
+    } Suite##_##Name##_instance; \
+    } \
+    void Suite##_##Name()
+
+#define EXPECT_TRUE(expr) \
+    do { if(!(expr)) throw std::runtime_error("EXPECT_TRUE failed: " #expr); } while(0)
+
+#define EXPECT_EQ(a,b) \
+    do { if(!((a)==(b))) throw std::runtime_error("EXPECT_EQ failed"); } while(0)
+
+#define EXPECT_NE(a,b) \
+    do { if(!((a)!=(b))) throw std::runtime_error("EXPECT_NE failed"); } while(0)
+
+#define EXPECT_LT(a,b) \
+    do { if(!((a)<(b))) throw std::runtime_error("EXPECT_LT failed"); } while(0)
+
+#endif // GTEST_GTEST_H

--- a/gtest/gtest_main.cpp
+++ b/gtest/gtest_main.cpp
@@ -1,0 +1,5 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+    return testing::RunAllTests();
+}

--- a/tests/test_blockchain.cpp
+++ b/tests/test_blockchain.cpp
@@ -21,3 +21,12 @@ TEST(BlockChainTest, InsertBlocks) {
     EXPECT_EQ(chain.getFront().getCurrNumTran(), 1);
 }
 
+TEST(BlockChainTest, VerifyChainIntegrity) {
+    blockChain chain(2);
+    transaction t1(0, 1, 1, 2, 10, "t1");
+    transaction t2(0, 2, 2, 3, 20, "t2");
+    chain.insertTran(t1);
+    chain.insertTran(t2);
+    EXPECT_TRUE(chain.verifyChain());
+}
+

--- a/tests/test_network.cpp
+++ b/tests/test_network.cpp
@@ -16,3 +16,10 @@ TEST(BlockNetworkTest, DisplayOutput) {
     EXPECT_NE(output.find("Block Number"), std::string::npos);
 }
 
+TEST(BlockNetworkTest, VerifyAllChains) {
+    blockNetwork net(1, 2);
+    transaction t(0, 1, 1, 2, 5, "ts");
+    net.insertTranToNode(0, t);
+    EXPECT_TRUE(net.verifyAllChains());
+}
+


### PR DESCRIPTION
## Summary
- add hash fields and previous hash linkage in `block`
- compute block hash when transactions are inserted
- add `verifyChain` for `blockChain` and `verifyAllChains` for `blockNetwork`
- test new verification functions
- implement tiny in-repo gtest to avoid network fetch

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
