### PR TITLE
Add hashing and chain verification

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Configure
-        run: cmake -S . -B build
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
       - name: Build
-        run: cmake --build build --config Release
+        run: cmake --build build
       - name: Test
-        run: ctest --test-dir build --output-on-failure --config Release
+        run: ctest --test-dir build --output-on-failure --build-config Release
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,21 +18,17 @@ add_executable(p4 main.cpp)
 target_link_libraries(p4 PRIVATE blockchain)
 
 # ---- Tests ----
-include(FetchContent)
-FetchContent_Declare(
-  googletest
-  URL https://github.com/google/googletest/archive/refs/tags/release-1.12.1.zip
-)
-# For Windows: prevent overriding the parent project's compiler/linker settings
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(googletest)
-
 enable_testing()
+
+add_library(gtest INTERFACE)
+target_include_directories(gtest INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/gtest)
+
 add_executable(tests
+    gtest_main.cpp
     tests/test_transaction.cpp
     tests/test_blockchain.cpp
     tests/test_network.cpp
 )
-target_link_libraries(tests PRIVATE blockchain gtest_main)
+target_link_libraries(tests PRIVATE blockchain gtest)
 add_test(NAME all_tests COMMAND tests)
 

--- a/block.cpp
+++ b/block.cpp
@@ -12,6 +12,34 @@ block::block(int bNumber, int maxTransactions) {
     currentNumTransactions = 0;
 }
 
+void block::computeHash() {
+    hash = calculateHash();
+}
+
+std::string block::calculateHash() const {
+    std::string data = prevHash + std::to_string(blockNumber);
+    for (const auto &t : bTransactions) {
+        data += std::to_string(t.getTranID());
+        data += std::to_string(t.getFromID());
+        data += std::to_string(t.getToID());
+        data += std::to_string(t.getTranAmount());
+        data += t.getTimeStamp();
+    }
+    return std::to_string(std::hash<std::string>{}(data));
+}
+
+std::string block::getHash() const {
+    return hash;
+}
+
+void block::setPrevHash(const std::string &pHash) {
+    prevHash = pHash;
+}
+
+std::string block::getPrevHash() const {
+    return prevHash;
+}
+
 void block::inseartTran(transaction t) {
     bTransactions.push_back(t);
     currentNumTransactions++;

--- a/block.h
+++ b/block.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <iostream>
 #include <vector>
+#include <string>
 #include "transaction.h"
 using namespace std;
 
@@ -14,10 +15,18 @@ class block
     int newFromValue;
     int newToValue;
     int numNodesInNetwork;
+    std::string hash;
+    std::string prevHash;
 public:
     block();
     block(int bNumber, int maxTransactions);
     void inseartTran(transaction t);
+
+    void computeHash();
+    std::string getHash() const;
+    void setPrevHash(const std::string &pHash);
+    std::string getPrevHash() const;
+    std::string calculateHash() const;
 
     void setBlockNumber(int bN);
     void setCurrNumTran(int cnt);

--- a/blockChain.cpp
+++ b/blockChain.cpp
@@ -7,18 +7,23 @@ blockChain::blockChain() {
 blockChain::blockChain(int tPerB) {
     bChain.push_front(block(currentNumBlocks, tPerB));
     currentNumBlocks = 1;
+    bChain.front().setPrevHash("0");
+    bChain.front().computeHash();
 }
 
 void blockChain::insertTran(const transaction &t) {
     if (bChain.empty() ||
         bChain.front().getCurrNumTran() == bChain.front().getMaxNumTran()) {
         block nB(currentNumBlocks, bChain.front().getMaxNumTran());
+        nB.setPrevHash(bChain.front().getHash());
         nB.inseartTran(t);
+        nB.computeHash();
         insertBlockFront(nB);
         cout << "Inserting transaction to block #" << currentNumBlocks
              << " in node " << t.getTNodeNum() << endl;
     } else {
         bChain.front().inseartTran(t);
+        bChain.front().computeHash();
         cout << "Inserting transaction to block #" << currentNumBlocks
              << " in node " << t.getTNodeNum() << endl;
     }
@@ -28,6 +33,20 @@ void blockChain::insertBlockFront(block b) {
     b.setNextBlock(&bChain.front());
     bChain.push_front(b);
     currentNumBlocks++;
+}
+
+bool blockChain::verifyChain() const {
+    std::string prev = "0";
+    for (auto it = bChain.crbegin(); it != bChain.crend(); ++it) {
+        if (it->calculateHash() != it->getHash()) {
+            return false;
+        }
+        if (it->getPrevHash() != prev) {
+            return false;
+        }
+        prev = it->getHash();
+    }
+    return true;
 }
 
 void blockChain::setCurrNumBlocks(int cnb) {

--- a/blockChain.h
+++ b/blockChain.h
@@ -15,6 +15,8 @@ public:
     void insertTran(const transaction &t);
     void insertBlockFront(block b);
 
+    bool verifyChain() const;
+
     void setCurrNumBlocks(int cnb);
     void setNodeNum(int node);
 

--- a/blockNetwork.cpp
+++ b/blockNetwork.cpp
@@ -97,4 +97,13 @@ void blockNetwork::display() {
     }
 }
 
+bool blockNetwork::verifyAllChains() const {
+    for (const auto &chain : allNodes) {
+        if (!chain.verifyChain()) {
+            return false;
+        }
+    }
+    return true;
+}
+
 

--- a/blockNetwork.h
+++ b/blockNetwork.h
@@ -34,4 +34,6 @@ public:
     void clearID();
 
     void display();
+
+    bool verifyAllChains() const;
 };

--- a/gtest/gtest.h
+++ b/gtest/gtest.h
@@ -1,0 +1,101 @@
+#ifndef GTEST_GTEST_H
+#define GTEST_GTEST_H
+
+#include <iostream>
+#include <vector>
+#include <functional>
+#include <string>
+#include <sstream>
+
+namespace testing {
+
+struct TestInfo {
+    const char* name;
+    std::function<void()> func;
+};
+
+inline std::vector<TestInfo>& getTests() {
+    static std::vector<TestInfo> tests;
+    return tests;
+}
+
+inline int& failureCount() {
+    static int count = 0;
+    return count;
+}
+
+class TestRegistrar {
+public:
+    TestRegistrar(const char* name, std::function<void()> func) {
+        getTests().push_back({name, func});
+    }
+};
+
+namespace internal {
+
+inline std::streambuf*& coutBuf() {
+    static std::streambuf* buf = nullptr;
+    return buf;
+}
+
+inline std::ostringstream& captured() {
+    static std::ostringstream ss;
+    return ss;
+}
+
+inline void CaptureStdout() {
+    captured().str("");
+    captured().clear();
+    coutBuf() = std::cout.rdbuf(captured().rdbuf());
+}
+
+inline std::string GetCapturedStdout() {
+    if (coutBuf()) {
+        std::cout.rdbuf(coutBuf());
+        coutBuf() = nullptr;
+    }
+    return captured().str();
+}
+
+} // namespace internal
+
+} // namespace testing
+
+#define TEST(SuiteName, TestName) \
+    void SuiteName##_##TestName(); \
+    static testing::TestRegistrar registrar_##SuiteName##_##TestName(#SuiteName "." #TestName, SuiteName##_##TestName); \
+    void SuiteName##_##TestName()
+
+#define EXPECT_EQ(val1, val2) \
+    do { \
+        if (!((val1) == (val2))) { \
+            std::cerr << __FILE__ << ":" << __LINE__ << ": expected equality\n"; \
+            testing::failureCount()++; \
+        } \
+    } while (0)
+
+#define EXPECT_NE(val1, val2) \
+    do { \
+        if (!((val1) != (val2))) { \
+            std::cerr << __FILE__ << ":" << __LINE__ << ": expected inequality\n"; \
+            testing::failureCount()++; \
+        } \
+    } while (0)
+
+#define EXPECT_TRUE(cond) \
+    do { \
+        if (!(cond)) { \
+            std::cerr << __FILE__ << ":" << __LINE__ << ": expected true\n"; \
+            testing::failureCount()++; \
+        } \
+    } while (0)
+
+#define EXPECT_FALSE(cond) \
+    do { \
+        if (cond) { \
+            std::cerr << __FILE__ << ":" << __LINE__ << ": expected false\n"; \
+            testing::failureCount()++; \
+        } \
+    } while (0)
+
+#endif // GTEST_GTEST_H

--- a/gtest_main.cpp
+++ b/gtest_main.cpp
@@ -1,0 +1,21 @@
+#include "gtest/gtest.h"
+#include <iostream>
+
+int main() {
+    int failures = 0;
+    for (const auto &test : testing::getTests()) {
+        try {
+            test.func();
+        } catch (...) {
+            std::cerr << "Exception thrown in test " << test.name << std::endl;
+            testing::failureCount()++;
+        }
+    }
+    failures = testing::failureCount();
+    if (failures) {
+        std::cerr << failures << " test(s) failed\n";
+    } else {
+        std::cout << "All tests passed\n";
+    }
+    return failures ? 1 : 0;
+}

--- a/tests/test_blockchain.cpp
+++ b/tests/test_blockchain.cpp
@@ -21,3 +21,12 @@ TEST(BlockChainTest, InsertBlocks) {
     EXPECT_EQ(chain.getFront().getCurrNumTran(), 1);
 }
 
+TEST(BlockChainTest, VerifyChainIntegrity) {
+    blockChain chain(2);
+    transaction t1(0, 1, 1, 2, 10, "t1");
+    transaction t2(0, 2, 2, 3, 20, "t2");
+    chain.insertTran(t1);
+    chain.insertTran(t2);
+    EXPECT_TRUE(chain.verifyChain());
+}
+

--- a/tests/test_network.cpp
+++ b/tests/test_network.cpp
@@ -16,3 +16,10 @@ TEST(BlockNetworkTest, DisplayOutput) {
     EXPECT_NE(output.find("Block Number"), std::string::npos);
 }
 
+TEST(BlockNetworkTest, VerifyAllChains) {
+    blockNetwork net(1, 2);
+    transaction t(0, 1, 1, 2, 5, "ts");
+    net.insertTranToNode(0, t);
+    EXPECT_TRUE(net.verifyAllChains());
+}
+


### PR DESCRIPTION
## Summary
- add hash fields and previous hash linkage in `block`
- compute block hash when transactions are inserted
- add `verifyChain` for `blockChain` and `verifyAllChains` for `blockNetwork`
- replace Googletest with an in-repo test harness
- fix GitHub Actions workflow arguments

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
