### PR TITLE
Add hashing verification and local test harness

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -17,5 +17,5 @@ jobs:
       - name: Build
         run: cmake --build build --config Release
       - name: Test
-        run: ctest --test-dir build --output-on-failure --config Release
+        run: ctest --test-dir build --output-on-failure --build-config Release
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,21 +18,14 @@ add_executable(p4 main.cpp)
 target_link_libraries(p4 PRIVATE blockchain)
 
 # ---- Tests ----
-include(FetchContent)
-FetchContent_Declare(
-  googletest
-  URL https://github.com/google/googletest/archive/refs/tags/release-1.12.1.zip
-)
-# For Windows: prevent overriding the parent project's compiler/linker settings
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(googletest)
-
 enable_testing()
 add_executable(tests
     tests/test_transaction.cpp
     tests/test_blockchain.cpp
     tests/test_network.cpp
+    gtest/gtest_main.cpp
 )
-target_link_libraries(tests PRIVATE blockchain gtest_main)
+target_include_directories(tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(tests PRIVATE blockchain)
 add_test(NAME all_tests COMMAND tests)
 

--- a/block.cpp
+++ b/block.cpp
@@ -12,6 +12,34 @@ block::block(int bNumber, int maxTransactions) {
     currentNumTransactions = 0;
 }
 
+void block::computeHash() {
+    hash = calculateHash();
+}
+
+std::string block::calculateHash() const {
+    std::string data = prevHash + std::to_string(blockNumber);
+    for (const auto &t : bTransactions) {
+        data += std::to_string(t.getTranID());
+        data += std::to_string(t.getFromID());
+        data += std::to_string(t.getToID());
+        data += std::to_string(t.getTranAmount());
+        data += t.getTimeStamp();
+    }
+    return std::to_string(std::hash<std::string>{}(data));
+}
+
+std::string block::getHash() const {
+    return hash;
+}
+
+void block::setPrevHash(const std::string &pHash) {
+    prevHash = pHash;
+}
+
+std::string block::getPrevHash() const {
+    return prevHash;
+}
+
 void block::inseartTran(transaction t) {
     bTransactions.push_back(t);
     currentNumTransactions++;

--- a/block.h
+++ b/block.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <iostream>
 #include <vector>
+#include <string>
 #include "transaction.h"
 using namespace std;
 
@@ -14,10 +15,18 @@ class block
     int newFromValue;
     int newToValue;
     int numNodesInNetwork;
+    std::string hash;
+    std::string prevHash;
 public:
     block();
     block(int bNumber, int maxTransactions);
     void inseartTran(transaction t);
+
+    void computeHash();
+    std::string getHash() const;
+    void setPrevHash(const std::string &pHash);
+    std::string getPrevHash() const;
+    std::string calculateHash() const;
 
     void setBlockNumber(int bN);
     void setCurrNumTran(int cnt);

--- a/blockChain.cpp
+++ b/blockChain.cpp
@@ -7,18 +7,23 @@ blockChain::blockChain() {
 blockChain::blockChain(int tPerB) {
     bChain.push_front(block(currentNumBlocks, tPerB));
     currentNumBlocks = 1;
+    bChain.front().setPrevHash("0");
+    bChain.front().computeHash();
 }
 
 void blockChain::insertTran(const transaction &t) {
     if (bChain.empty() ||
         bChain.front().getCurrNumTran() == bChain.front().getMaxNumTran()) {
         block nB(currentNumBlocks, bChain.front().getMaxNumTran());
+        nB.setPrevHash(bChain.front().getHash());
         nB.inseartTran(t);
+        nB.computeHash();
         insertBlockFront(nB);
         cout << "Inserting transaction to block #" << currentNumBlocks
              << " in node " << t.getTNodeNum() << endl;
     } else {
         bChain.front().inseartTran(t);
+        bChain.front().computeHash();
         cout << "Inserting transaction to block #" << currentNumBlocks
              << " in node " << t.getTNodeNum() << endl;
     }
@@ -28,6 +33,20 @@ void blockChain::insertBlockFront(block b) {
     b.setNextBlock(&bChain.front());
     bChain.push_front(b);
     currentNumBlocks++;
+}
+
+bool blockChain::verifyChain() const {
+    std::string prev = "0";
+    for (auto it = bChain.crbegin(); it != bChain.crend(); ++it) {
+        if (it->calculateHash() != it->getHash()) {
+            return false;
+        }
+        if (it->getPrevHash() != prev) {
+            return false;
+        }
+        prev = it->getHash();
+    }
+    return true;
 }
 
 void blockChain::setCurrNumBlocks(int cnb) {

--- a/blockChain.h
+++ b/blockChain.h
@@ -15,6 +15,8 @@ public:
     void insertTran(const transaction &t);
     void insertBlockFront(block b);
 
+    bool verifyChain() const;
+
     void setCurrNumBlocks(int cnb);
     void setNodeNum(int node);
 

--- a/blockNetwork.cpp
+++ b/blockNetwork.cpp
@@ -97,4 +97,13 @@ void blockNetwork::display() {
     }
 }
 
+bool blockNetwork::verifyAllChains() const {
+    for (const auto &chain : allNodes) {
+        if (!chain.verifyChain()) {
+            return false;
+        }
+    }
+    return true;
+}
+
 

--- a/blockNetwork.h
+++ b/blockNetwork.h
@@ -34,4 +34,6 @@ public:
     void clearID();
 
     void display();
+
+    bool verifyAllChains() const;
 };

--- a/gtest/gtest.h
+++ b/gtest/gtest.h
@@ -1,0 +1,64 @@
+#pragma once
+#include <iostream>
+#include <vector>
+#include <functional>
+#include <string>
+
+struct TestEntry {
+    std::string name;
+    std::function<void()> func;
+};
+
+inline int &GetFailureCount() {
+    static int count = 0;
+    return count;
+}
+
+inline std::vector<TestEntry>& GetTests() {
+    static std::vector<TestEntry> tests;
+    return tests;
+}
+
+struct TestRegistrar {
+    TestRegistrar(const std::string& n, std::function<void()> f) {
+        GetTests().push_back({n, f});
+    }
+};
+
+#define TEST(suite, name) \
+    void suite##_##name(); \
+    static TestRegistrar registrar_##suite##_##name(#suite "." #name, suite##_##name); \
+    void suite##_##name()
+
+#define EXPECT_EQ(val1, val2) \
+    do { \
+        auto v1 = (val1); \
+        auto v2 = (val2); \
+        if (!(v1 == v2)) { \
+            std::cerr << __FILE__ << ":" << __LINE__ << " Expectation failed: " \
+                      << #val1 << " == " << #val2 \
+                      << " (" << v1 << " vs " << v2 << ")" << std::endl; \
+            ++GetFailureCount(); \
+        } \
+    } while (0)
+
+#define EXPECT_TRUE(cond) \
+    do { \
+        if (!(cond)) { \
+            std::cerr << __FILE__ << ":" << __LINE__ << " Expectation failed: " \
+                      << #cond << std::endl; \
+            ++GetFailureCount(); \
+        } \
+    } while (0)
+
+#define EXPECT_NE(val1, val2) \
+    do { \
+        auto v1 = (val1); \
+        auto v2 = (val2); \
+        if (v1 == v2) { \
+            std::cerr << __FILE__ << ":" << __LINE__ << " Expectation failed: " \
+                      << #val1 << " != " << #val2 << std::endl; \
+            ++GetFailureCount(); \
+        } \
+    } while (0)
+

--- a/gtest/gtest_main.cpp
+++ b/gtest/gtest_main.cpp
@@ -1,0 +1,25 @@
+#include "gtest.h"
+#include <iostream>
+
+std::vector<TestEntry>& GetTests();
+
+int main() {
+    int failures = 0;
+    for (const auto& t : GetTests()) {
+        try {
+            t.func();
+        } catch (const std::exception& e) {
+            std::cerr << t.name << " threw exception: " << e.what() << std::endl;
+            ++failures;
+            continue;
+        }
+        failures += GetFailureCount();
+        GetFailureCount() = 0;
+    }
+    if (failures) {
+        std::cerr << failures << " tests failed" << std::endl;
+        return 1;
+    }
+    std::cout << "All tests passed" << std::endl;
+    return 0;
+}

--- a/tests/test_blockchain.cpp
+++ b/tests/test_blockchain.cpp
@@ -21,3 +21,12 @@ TEST(BlockChainTest, InsertBlocks) {
     EXPECT_EQ(chain.getFront().getCurrNumTran(), 1);
 }
 
+TEST(BlockChainTest, VerifyChainIntegrity) {
+    blockChain chain(2);
+    transaction t1(0, 1, 1, 2, 10, "t1");
+    transaction t2(0, 2, 2, 3, 20, "t2");
+    chain.insertTran(t1);
+    chain.insertTran(t2);
+    EXPECT_TRUE(chain.verifyChain());
+}
+

--- a/tests/test_network.cpp
+++ b/tests/test_network.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <string>
 #include <iostream>
+#include <sstream>
 #include "blockNetwork.h"
 
 TEST(BlockNetworkTest, DisplayOutput) {
@@ -8,11 +9,20 @@ TEST(BlockNetworkTest, DisplayOutput) {
     transaction t(0, 1, 1, 2, 5, "ts");
     net.insertTranToNode(0, t);
 
-    testing::internal::CaptureStdout();
+    std::ostringstream oss;
+    auto* old = std::cout.rdbuf(oss.rdbuf());
     net.display();
-    std::string output = testing::internal::GetCapturedStdout();
+    std::cout.rdbuf(old);
+    std::string output = oss.str();
 
     EXPECT_NE(output.find("Node 0"), std::string::npos);
     EXPECT_NE(output.find("Block Number"), std::string::npos);
+}
+
+TEST(BlockNetworkTest, VerifyAllChains) {
+    blockNetwork net(1, 2);
+    transaction t(0, 1, 1, 2, 5, "ts");
+    net.insertTranToNode(0, t);
+    EXPECT_TRUE(net.verifyAllChains());
 }
 


### PR DESCRIPTION
## Summary
- add hash functions and previous-hash tracking in blocks
- verify blockchain integrity with `verifyChain` and network-wide with `verifyAllChains`
- implement a tiny in-repo gtest replacement and adjust tests to use it
- fix `ctest` invocation in CI workflow

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
