### PR TITLE
Implement blockchain hash verification and tamper tests

### DIFF
--- a/blockChain.cpp
+++ b/blockChain.cpp
@@ -49,6 +49,18 @@ bool blockChain::verifyChain() const {
     return true;
 }
 
+void blockChain::tamperPrevHash(size_t index, const std::string &newPrev) {
+    auto it = bChain.begin();
+    size_t i = 0;
+    while (i < index && it != bChain.end()) {
+        ++it;
+        ++i;
+    }
+    if (it != bChain.end()) {
+        it->setPrevHash(newPrev);
+    }
+}
+
 void blockChain::setCurrNumBlocks(int cnb) {
     currentNumBlocks = cnb;
 }

--- a/blockChain.h
+++ b/blockChain.h
@@ -17,6 +17,9 @@ public:
 
     bool verifyChain() const;
 
+    // Intentionally modify the prevHash of a block for testing
+    void tamperPrevHash(size_t index, const std::string &newPrev);
+
     void setCurrNumBlocks(int cnb);
     void setNodeNum(int node);
 

--- a/blockNetwork.cpp
+++ b/blockNetwork.cpp
@@ -106,4 +106,10 @@ bool blockNetwork::verifyAllChains() const {
     return true;
 }
 
+void blockNetwork::tamperPrevHash(size_t nodeIndex, size_t blockIndex, const std::string &newPrev) {
+    if (nodeIndex < allNodes.size()) {
+        allNodes[nodeIndex].tamperPrevHash(blockIndex, newPrev);
+    }
+}
+
 

--- a/blockNetwork.h
+++ b/blockNetwork.h
@@ -36,4 +36,7 @@ public:
     void display();
 
     bool verifyAllChains() const;
+
+    // Modify prevHash of a block in a given node for testing
+    void tamperPrevHash(size_t nodeIndex, size_t blockIndex, const std::string &newPrev);
 };

--- a/tests/test_blockchain.cpp
+++ b/tests/test_blockchain.cpp
@@ -30,3 +30,13 @@ TEST(BlockChainTest, VerifyChainIntegrity) {
     EXPECT_TRUE(chain.verifyChain());
 }
 
+TEST(BlockChainTest, DetectTampering) {
+    blockChain chain(2);
+    transaction t1(0, 1, 1, 2, 10, "t1");
+    transaction t2(0, 2, 2, 3, 20, "t2");
+    chain.insertTran(t1);
+    chain.insertTran(t2);
+    chain.tamperPrevHash(0, "badhash");
+    EXPECT_TRUE(!chain.verifyChain());
+}
+

--- a/tests/test_network.cpp
+++ b/tests/test_network.cpp
@@ -26,3 +26,13 @@ TEST(BlockNetworkTest, VerifyAllChains) {
     EXPECT_TRUE(net.verifyAllChains());
 }
 
+TEST(BlockNetworkTest, DetectTampering) {
+    blockNetwork net(1, 2);
+    transaction t1(0, 1, 1, 2, 5, "ts");
+    transaction t2(0, 2, 2, 3, 7, "ts2");
+    net.insertTranToNode(0, t1);
+    net.insertTranToNode(0, t2);
+    net.tamperPrevHash(0, 0, "bad");
+    EXPECT_TRUE(!net.verifyAllChains());
+}
+


### PR DESCRIPTION
## Summary
- add tamper helpers to modify block `prevHash`
- expose tamper functions on `blockChain` and `blockNetwork`
- add unit tests showing tampering detection

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`